### PR TITLE
Filtering and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ AI route-setting via [`kilter_brain_gen`](https://github.com/rparrett/kilter_bra
 
 ## TODO
 
-- native: Automatic updates from kilter API
-- ios: It's probably possible to get sqlite to work
+- Automatic route updates from kilter API
 - Add route authoring
   - [X] Edit placements
   - [ ] Edit name, setter name, description, etc.

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -11,7 +11,7 @@ use std::fmt::Write;
 use crate::{
     clipboard::PasteEvent,
     kilter_board::{Board, KilterSettings, SelectedClimb},
-    kilter_data::{parse_placements_and_roles, Climb, KilterData},
+    kilter_data::{parse_placements_and_roles, Climb, ClimbFilter, KilterData},
     placement_indicator::PlacementIndicator,
 };
 
@@ -160,8 +160,11 @@ fn on_paste(
     mut events: EventReader<PasteEvent>,
     mut selected: ResMut<SelectedClimb>,
     mut kilter: ResMut<KilterData>,
+    mut filter: ResMut<ClimbFilter>,
 ) {
     for event in events.read() {
+        let mut to_add = vec![];
+
         let lines = event.0.split('\n');
         for (l, line) in lines.enumerate() {
             let line = line.trim();
@@ -184,20 +187,26 @@ fn on_paste(
 
             let id = Uuid::new_v4().simple().to_string();
 
-            kilter.climbs.insert(
-                id.clone(),
-                Climb {
-                    uuid: id.clone(),
-                    setter_username: "User".to_string(),
-                    name: name.to_string(),
-                    frames: frames.to_string(),
-                    ..default()
-                },
-            );
+            to_add.push(Climb {
+                uuid: id.clone(),
+                setter_username: "User".to_string(),
+                name: name.to_string(),
+                frames: frames.to_string(),
+                ..default()
+            });
 
             // TODO we need a filter mode that is just "show recently generated climbs," or
             // "most recent (no filter)"
             selected.0 = id.clone();
+        }
+
+        if !to_add.is_empty() {
+            filter.override_climbs.clear();
+            for climb in to_add {
+                filter.override_climbs.insert(climb.uuid.clone());
+                kilter.climbs.insert(climb.uuid.clone(), climb);
+            }
+            filter.update(&kilter);
         }
     }
 }

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -162,8 +162,6 @@ fn on_paste(
     mut kilter: ResMut<KilterData>,
 ) {
     for event in events.read() {
-        let mut added = 0;
-
         let lines = event.0.split('\n');
         for (l, line) in lines.enumerate() {
             let line = line.trim();
@@ -197,11 +195,9 @@ fn on_paste(
                 },
             );
 
-            added += 1;
-        }
-
-        if added > 0 {
-            selected.0 = kilter.climbs.len() - added;
+            // TODO we need a filter mode that is just "show recently generated climbs," or
+            // "most recent (no filter)"
+            selected.0 = id.clone();
         }
     }
 }

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -195,8 +195,6 @@ fn on_paste(
                 ..default()
             });
 
-            // TODO we need a filter mode that is just "show recently generated climbs," or
-            // "most recent (no filter)"
             selected.0 = id.clone();
         }
 

--- a/src/gen_api.rs
+++ b/src/gen_api.rs
@@ -4,7 +4,7 @@ use serde_derive::Deserialize;
 
 use crate::{
     kilter_board::SelectedClimb,
-    kilter_data::{Climb, KilterData},
+    kilter_data::{Climb, ClimbFilter, KilterData},
 };
 
 pub struct GenApiPlugin;
@@ -54,8 +54,10 @@ fn handle_response(
     mut ev_response: EventReader<TypedResponse<GeneratedClimbs>>,
     mut kilter: ResMut<KilterData>,
     mut selected: ResMut<SelectedClimb>,
+    mut filter: ResMut<ClimbFilter>,
 ) {
     for response in ev_response.read() {
+        filter.override_climbs.clear();
         for generated_climb in &**response {
             kilter.climbs.insert(
                 generated_climb.uuid.clone(),
@@ -73,7 +75,9 @@ fn handle_response(
             // TODO we need a filter mode that is just "show recently generated climbs," or
             // "most recent (no filter)"
             selected.0 = generated_climb.uuid.clone();
+            filter.override_climbs.insert(generated_climb.uuid.clone());
         }
+        filter.update(&kilter);
     }
 }
 

--- a/src/gen_api.rs
+++ b/src/gen_api.rs
@@ -72,8 +72,6 @@ fn handle_response(
                 },
             );
 
-            // TODO we need a filter mode that is just "show recently generated climbs," or
-            // "most recent (no filter)"
             selected.0 = generated_climb.uuid.clone();
             filter.override_climbs.insert(generated_climb.uuid.clone());
         }

--- a/src/gen_api.rs
+++ b/src/gen_api.rs
@@ -69,9 +69,11 @@ fn handle_response(
                     ..default()
                 },
             );
-        }
 
-        selected.0 = kilter.climbs.len() - response.len();
+            // TODO we need a filter mode that is just "show recently generated climbs," or
+            // "most recent (no filter)"
+            selected.0 = generated_climb.uuid.clone();
+        }
     }
 }
 

--- a/src/kilter_board.rs
+++ b/src/kilter_board.rs
@@ -3,12 +3,12 @@ use combine::EasyParser;
 
 use crate::{
     board_connection::WriteToBoard,
-    kilter_data::{placements_and_roles, KilterData},
+    kilter_data::{placements_and_roles, ClimbFilter, KilterData},
     placement_indicator::PlacementIndicator,
 };
 
-#[derive(Resource, Default)]
-pub struct SelectedClimb(pub usize);
+#[derive(Resource)]
+pub struct SelectedClimb(pub String);
 
 #[derive(Component)]
 pub struct Board;
@@ -17,7 +17,7 @@ pub struct Board;
 pub enum ChangeClimbEvent {
     Prev,
     Next,
-    SelectByIndex(usize),
+    SelectByUuid(String),
 }
 
 #[derive(Reflect, Resource)]
@@ -72,7 +72,6 @@ impl Plugin for KilterBoardPlugin {
         .add_systems(Startup, setup_scene)
         .add_event::<ChangeClimbEvent>()
         .init_resource::<BoardAngle>()
-        .init_resource::<SelectedClimb>()
         .init_resource::<KilterSettings>()
         .register_type::<KilterSettings>();
     }
@@ -138,28 +137,32 @@ fn prev_next_climb(keys: Res<ButtonInput<KeyCode>>, mut writer: EventWriter<Chan
 
 fn change_climb(
     mut selected: ResMut<SelectedClimb>,
-    kilter: Res<KilterData>,
+    filter: Res<ClimbFilter>,
     mut reader: EventReader<ChangeClimbEvent>,
 ) {
     for event in reader.read() {
         match event {
             ChangeClimbEvent::Prev => {
-                selected.0 = if selected.0 == 0 {
-                    kilter.climbs.len() - 1
+                let current = filter.filtered_climbs.get_index_of(&selected.0).unwrap();
+                let prev = if current == 0 {
+                    filter.filtered_climbs.len() - 1
                 } else {
-                    selected.0 - 1
+                    current - 1
                 };
+                selected.0 = filter.filtered_climbs.get_index(prev).unwrap().clone();
             }
             ChangeClimbEvent::Next => {
-                selected.0 = if selected.0 + 1 >= kilter.climbs.len() {
+                let current = filter.filtered_climbs.get_index_of(&selected.0).unwrap();
+
+                let next = if current + 1 >= filter.filtered_climbs.len() {
                     0
                 } else {
-                    selected.0 + 1
+                    current + 1
                 };
+
+                selected.0 = filter.filtered_climbs.get_index(next).unwrap().clone();
             }
-            ChangeClimbEvent::SelectByIndex(id) => {
-                selected.0 = *id;
-            }
+            ChangeClimbEvent::SelectByUuid(uuid) => selected.0 = uuid.clone(),
         }
     }
 }
@@ -181,14 +184,7 @@ fn show_climb(
         return;
     };
 
-    // Get selected or first climb
-    let Some(climb) = kilter
-        .climbs
-        .iter()
-        .nth(selected.0)
-        .or_else(|| kilter.climbs.iter().next())
-        .map(|(_, climb)| climb)
-    else {
+    let Some(climb) = kilter.climbs.get(&selected.0) else {
         return;
     };
 

--- a/src/kilter_board.rs
+++ b/src/kilter_board.rs
@@ -143,24 +143,52 @@ fn change_climb(
     for event in reader.read() {
         match event {
             ChangeClimbEvent::Prev => {
-                let current = filter.filtered_climbs.get_index_of(&selected.0).unwrap();
-                let prev = if current == 0 {
+                if filter.filtered_climbs.is_empty() {
+                    continue;
+                }
+
+                let current_index = filter
+                    .filtered_climbs
+                    .get_index_of(&selected.0)
+                    .unwrap_or(0);
+
+                info!("Current index: {current_index}");
+
+                let prev_index = if current_index == 0 {
                     filter.filtered_climbs.len() - 1
                 } else {
-                    current - 1
+                    current_index - 1
                 };
-                selected.0 = filter.filtered_climbs.get_index(prev).unwrap().clone();
+
+                info!("Prev index: {prev_index}");
+
+                if let Some(prev_uuid) = filter.filtered_climbs.get_index(prev_index) {
+                    selected.0 = prev_uuid.clone();
+                }
             }
             ChangeClimbEvent::Next => {
-                let current = filter.filtered_climbs.get_index_of(&selected.0).unwrap();
+                if filter.filtered_climbs.is_empty() {
+                    continue;
+                }
 
-                let next = if current + 1 >= filter.filtered_climbs.len() {
+                let current_index = filter
+                    .filtered_climbs
+                    .get_index_of(&selected.0)
+                    .unwrap_or(0);
+
+                info!("Current index: {current_index}");
+
+                let next_index = if current_index + 1 >= filter.filtered_climbs.len() {
                     0
                 } else {
-                    current + 1
+                    current_index + 1
                 };
 
-                selected.0 = filter.filtered_climbs.get_index(next).unwrap().clone();
+                info!("Next index: {next_index}");
+
+                if let Some(next_uuid) = filter.filtered_climbs.get_index(next_index) {
+                    selected.0 = next_uuid.clone();
+                }
             }
             ChangeClimbEvent::SelectByUuid(uuid) => selected.0 = uuid.clone(),
         }

--- a/src/kilter_board.rs
+++ b/src/kilter_board.rs
@@ -1,6 +1,5 @@
 use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 use combine::EasyParser;
-use indexmap::IndexSet;
 
 use crate::{
     board_connection::WriteToBoard,

--- a/src/kilter_board.rs
+++ b/src/kilter_board.rs
@@ -1,5 +1,6 @@
 use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 use combine::EasyParser;
+use indexmap::IndexSet;
 
 use crate::{
     board_connection::WriteToBoard,

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -516,6 +516,8 @@ fn weighted_rating(avg_rating: f32, num_ratings: u32, min_ratings: u32, global_a
 }
 
 // TODO can we parse into a HashMap<u32, u32>?
+// TODO this is probably too much unjustified complexity. The format is simple enough
+// that we don't really need fancy parse errors.
 pub fn placements_and_roles<'a, I>() -> impl Parser<I, Output = Vec<(u32, u32)>>
 where
     I: RangeStream<Token = char, Range = &'a str>,

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -34,7 +34,7 @@ pub struct Stats {
     climb_uuid: String,
     angle: u32,
     display_difficulty: f32,
-    benchmark_difficulty: f32,
+    benchmark_difficulty: Option<f32>,
     ascensionist_count: u32,
     difficulty_average: f32,
     quality_average: f32,
@@ -231,6 +231,7 @@ impl KilterData {
                 FROM climb_stats",
             )
             .unwrap();
+
         let uuid_angle_to_stats = stmt
             .query_map([], |row| {
                 Ok((
@@ -470,8 +471,6 @@ impl ClimbFilter {
 
             self.filtered_climbs.insert(uuid.clone());
         }
-
-        info!("filtered climbs: {}", self.filtered_climbs.len());
     }
 }
 

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -25,6 +25,7 @@ pub struct KilterData {
     pub climbs: IndexMap<String, Climb>,
     pub placement_id_to_led_position: HashMap<u32, u32>,
     pub uuid_angle_to_stats: HashMap<(String, u32), Stats>,
+    pub difficulty_grades: HashMap<u32, DifficultyGrade>,
 }
 
 #[expect(dead_code)]
@@ -39,6 +40,13 @@ pub struct Stats {
     quality_average: f32,
     fa_username: String,
     fa_at: String,
+}
+
+pub struct DifficultyGrade {
+    pub difficulty: u32,
+    pub boulder_name: String,
+    pub route_name: String,
+    pub is_listed: bool,
 }
 
 impl KilterData {
@@ -244,6 +252,30 @@ impl KilterData {
             .flatten()
             .collect::<HashMap<_, _>>();
 
+        let mut stmt = conn
+            .prepare(
+                "SELECT
+                    difficulty, boulder_name, route_name, is_listed
+                FROM difficulty_grades",
+            )
+            .unwrap();
+
+        let difficulty_grades = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    DifficultyGrade {
+                        difficulty: row.get(0)?,
+                        boulder_name: row.get(1)?,
+                        route_name: row.get(2)?,
+                        is_listed: row.get(3)?,
+                    },
+                ))
+            })
+            .unwrap()
+            .flatten()
+            .collect();
+
         Ok(Self {
             holes,
             placements,
@@ -252,6 +284,7 @@ impl KilterData {
             leds,
             placement_id_to_led_position,
             uuid_angle_to_stats,
+            difficulty_grades,
         })
     }
 
@@ -398,8 +431,24 @@ pub struct ClimbFilter {
     pub filter_min_difficulty: u32,
     pub filter_max_difficulty: u32,
 }
+impl Default for ClimbFilter {
+    fn default() -> Self {
+        Self {
+            filtered_climbs: Default::default(),
+            angle: Default::default(),
+            filter_min_difficulty: 20,
+            filter_max_difficulty: 20,
+        }
+    }
+}
 impl ClimbFilter {
-    fn update(&mut self, kilter_data: &KilterData) {
+    pub fn new(angle: u32, kilter_data: &KilterData) -> Self {
+        let mut cf = Self::default();
+        cf.angle = angle;
+        cf.update(&kilter_data);
+        cf
+    }
+    pub fn update(&mut self, kilter_data: &KilterData) {
         self.filtered_climbs.clear();
 
         for (uuid, _climb) in kilter_data.climbs.iter() {
@@ -421,6 +470,8 @@ impl ClimbFilter {
 
             self.filtered_climbs.insert(uuid.clone());
         }
+
+        info!("filtered climbs: {}", self.filtered_climbs.len());
     }
 }
 

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -1,6 +1,6 @@
 use bevy::platform::collections::HashMap;
 use combine::EasyParser;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::Read;
@@ -389,6 +389,39 @@ pub struct Led {
     pub product_size_id: u32,
     pub hole_id: u32,
     pub position: u32,
+}
+
+#[derive(Resource)]
+pub struct ClimbFilter {
+    pub filtered_climbs: IndexSet<String>,
+    pub angle: u32,
+    pub filter_min_difficulty: u32,
+    pub filter_max_difficulty: u32,
+}
+impl ClimbFilter {
+    fn update(&mut self, kilter_data: &KilterData) {
+        self.filtered_climbs.clear();
+
+        for (uuid, _climb) in kilter_data.climbs.iter() {
+            // TODO how can we avoid the `uuid` allocation here?
+            // TODO we need to be able to optionally skip difficulty filtering
+            // to show "open projects"
+            let Some(stats) = kilter_data
+                .uuid_angle_to_stats
+                .get(&(uuid.clone(), self.angle))
+            else {
+                continue;
+            };
+
+            if stats.display_difficulty < self.filter_min_difficulty as f32
+                || stats.display_difficulty > self.filter_max_difficulty as f32
+            {
+                continue;
+            }
+
+            self.filtered_climbs.insert(uuid.clone());
+        }
+    }
 }
 
 // TODO can we parse into a HashMap<u32, u32>?

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -1,3 +1,4 @@
+use bevy::math::FloatOrd;
 use bevy::platform::collections::HashMap;
 use combine::EasyParser;
 use indexmap::{IndexMap, IndexSet};
@@ -425,12 +426,19 @@ pub struct Led {
     pub position: u32,
 }
 
+#[derive(Default)]
+pub enum ClimbSort {
+    #[default]
+    Best,
+}
+
 #[derive(Resource)]
 pub struct ClimbFilter {
     pub filtered_climbs: IndexSet<String>,
     pub angle: u32,
     pub filter_min_difficulty: u32,
     pub filter_max_difficulty: u32,
+    pub sort: ClimbSort,
 }
 impl Default for ClimbFilter {
     fn default() -> Self {
@@ -439,6 +447,7 @@ impl Default for ClimbFilter {
             angle: Default::default(),
             filter_min_difficulty: 20,
             filter_max_difficulty: 20,
+            sort: Default::default(),
         }
     }
 }
@@ -471,7 +480,22 @@ impl ClimbFilter {
 
             self.filtered_climbs.insert(uuid.clone());
         }
+
+        self.filtered_climbs.sort_by_cached_key(|climb| {
+            let (rating, ascents) = kilter_data
+                .uuid_angle_to_stats
+                .get(&(climb.clone(), self.angle))
+                .map(|s| (s.quality_average, s.ascensionist_count))
+                .unwrap_or((0.0, 0));
+            // TODO global_avg
+            FloatOrd(-weighted_rating(rating, ascents, 10, 2.5))
+        });
     }
+}
+
+fn weighted_rating(avg_rating: f32, num_ratings: u32, min_ratings: u32, global_avg: f32) -> f32 {
+    let confidence = num_ratings as f32 / (num_ratings + min_ratings) as f32;
+    confidence * avg_rating + (1.0 - confidence) * global_avg
 }
 
 // TODO can we parse into a HashMap<u32, u32>?

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -445,8 +445,8 @@ impl Default for ClimbFilter {
         Self {
             filtered_climbs: Default::default(),
             angle: Default::default(),
-            filter_min_difficulty: 20,
-            filter_max_difficulty: 20,
+            filter_min_difficulty: 0,
+            filter_max_difficulty: 33,
             sort: Default::default(),
         }
     }

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -24,6 +24,21 @@ pub struct KilterData {
     pub placement_roles: HashMap<u32, PlacementRole>,
     pub climbs: IndexMap<String, Climb>,
     pub placement_id_to_led_position: HashMap<u32, u32>,
+    pub uuid_angle_to_stats: HashMap<(String, u32), Stats>,
+}
+
+#[expect(dead_code)]
+#[derive(Debug)]
+pub struct Stats {
+    climb_uuid: String,
+    angle: u32,
+    display_difficulty: f32,
+    benchmark_difficulty: f32,
+    ascensionist_count: u32,
+    difficulty_average: f32,
+    quality_average: f32,
+    fa_username: String,
+    fa_at: String,
 }
 
 impl KilterData {
@@ -193,6 +208,42 @@ impl KilterData {
             .flatten()
             .collect();
 
+        let mut stmt = conn
+            .prepare(
+                "SELECT
+                    climb_uuid,
+                    angle,
+                    display_difficulty,
+                    benchmark_difficulty,
+                    ascensionist_count,
+                    difficulty_average,
+                    quality_average,
+                    fa_username,
+                    fa_at
+                FROM climb_stats",
+            )
+            .unwrap();
+        let uuid_angle_to_stats = stmt
+            .query_map([], |row| {
+                Ok((
+                    (row.get(0)?, row.get(1)?),
+                    Stats {
+                        climb_uuid: row.get(0)?,
+                        angle: row.get(1)?,
+                        display_difficulty: row.get(2)?,
+                        benchmark_difficulty: row.get(3)?,
+                        ascensionist_count: row.get(4)?,
+                        difficulty_average: row.get(5)?,
+                        quality_average: row.get(6)?,
+                        fa_username: row.get(7)?,
+                        fa_at: row.get(8)?,
+                    },
+                ))
+            })
+            .unwrap()
+            .flatten()
+            .collect::<HashMap<_, _>>();
+
         Ok(Self {
             holes,
             placements,
@@ -200,6 +251,7 @@ impl KilterData {
             climbs,
             leds,
             placement_id_to_led_position,
+            uuid_angle_to_stats,
         })
     }
 

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -458,9 +458,13 @@ impl Default for ClimbFilter {
 }
 impl ClimbFilter {
     pub fn new(angle: u32, kilter_data: &KilterData) -> Self {
-        let mut cf = Self::default();
-        cf.angle = angle;
-        cf.update(&kilter_data);
+        let mut cf = Self {
+            angle,
+            ..Default::default()
+        };
+
+        cf.update(kilter_data);
+
         cf
     }
     pub fn update(&mut self, kilter_data: &KilterData) {

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -1,5 +1,5 @@
 use bevy::math::FloatOrd;
-use bevy::platform::collections::HashMap;
+use bevy::platform::collections::{HashMap, HashSet};
 use combine::EasyParser;
 use indexmap::{IndexMap, IndexSet};
 use serde_derive::{Deserialize, Serialize};
@@ -434,7 +434,11 @@ pub enum ClimbSort {
 
 #[derive(Resource)]
 pub struct ClimbFilter {
+    /// The set of climb UUIDs matching the current filters.
+    /// TODO this should be made private.
     pub filtered_climbs: IndexSet<String>,
+    /// If not empty, only show climbs from this set instead of doing normal filtering.
+    pub override_climbs: HashSet<String>,
     pub angle: u32,
     pub filter_min_difficulty: u32,
     pub filter_max_difficulty: u32,
@@ -444,6 +448,7 @@ impl Default for ClimbFilter {
     fn default() -> Self {
         Self {
             filtered_climbs: Default::default(),
+            override_climbs: Default::default(),
             angle: Default::default(),
             filter_min_difficulty: 0,
             filter_max_difficulty: 33,
@@ -462,6 +467,14 @@ impl ClimbFilter {
         self.filtered_climbs.clear();
 
         for (uuid, _climb) in kilter_data.climbs.iter() {
+            if !self.override_climbs.is_empty() {
+                if self.override_climbs.contains(uuid) {
+                    self.filtered_climbs.insert(uuid.clone());
+                }
+
+                continue;
+            }
+
             // TODO how can we avoid the `uuid` allocation here?
             // TODO we need to be able to optionally skip difficulty filtering
             // to show "open projects"

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -35,9 +35,9 @@ pub struct Stats {
     angle: u32,
     display_difficulty: f32,
     benchmark_difficulty: Option<f32>,
-    ascensionist_count: u32,
+    pub ascensionist_count: u32,
     difficulty_average: f32,
-    quality_average: f32,
+    pub quality_average: f32,
     fa_username: String,
     fa_at: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use pan_cam::PanCamPlugin;
 use placement_indicator::PlacementIndicatorPlugin;
 use ui::UiPlugin;
 
-use crate::{board_connection::BoardConnectionPlugin, effects::EffectsPlugin};
+use crate::{board_connection::BoardConnectionPlugin, effects::EffectsPlugin, nav::NavPlugin};
 
 mod authoring;
 pub mod board_connection;
@@ -21,6 +21,7 @@ mod gen_api;
 mod human;
 mod kilter_board;
 pub mod kilter_data;
+mod nav;
 mod pan_cam;
 mod placement_indicator;
 mod ui;
@@ -45,6 +46,7 @@ impl Plugin for AppPlugin {
             UiPlugin,
             BoardConnectionPlugin,
             EffectsPlugin,
+            NavPlugin,
         ));
 
         // Third-party Plugins

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+
+use crate::{
+    kilter_board::{BoardAngle, SelectedClimb},
+    kilter_data::{ClimbFilter, KilterData},
+};
+
+pub struct NavPlugin;
+impl Plugin for NavPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup);
+    }
+}
+
+fn setup(mut commands: Commands, data: Res<KilterData>, angle: Res<BoardAngle>) {
+    let filter = ClimbFilter::new(angle.0, &data);
+    // TODO handle empty data
+    commands.insert_resource(SelectedClimb(
+        filter.filtered_climbs.get_index(0).unwrap().clone(),
+    ));
+    commands.insert_resource(filter);
+}

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -14,7 +14,6 @@ impl Plugin for NavPlugin {
 
 fn setup(mut commands: Commands, data: Res<KilterData>, angle: Res<BoardAngle>) {
     let filter = ClimbFilter::new(angle.0, &data);
-    // TODO handle empty data
     commands.insert_resource(SelectedClimb(
         filter.filtered_climbs.get_index(0).unwrap().clone(),
     ));

--- a/src/ui/action_panel.rs
+++ b/src/ui/action_panel.rs
@@ -150,7 +150,7 @@ fn new_button(
             },
         );
 
-        selected.0 = kilter.climbs.len() - 1;
+        selected.0 = id.clone();
     }
 }
 
@@ -230,8 +230,7 @@ fn publish_button(
             out
         });
 
-        // Get selected or first climb
-        let Some((_, climb)) = kilter.climbs.iter().nth(selected.0) else {
+        let Some(climb) = kilter.climbs.get(&selected.0) else {
             return;
         };
 
@@ -260,7 +259,7 @@ fn open_climb_button(
     kilter: Res<KilterData>,
 ) {
     if query.iter().any(|i| *i == Interaction::Pressed) {
-        let Some((_, climb)) = kilter.climbs.iter().nth(selected.0) else {
+        let Some(climb) = kilter.climbs.get(&selected.0) else {
             return;
         };
 

--- a/src/ui/board_panel.rs
+++ b/src/ui/board_panel.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use crate::{
     board_connection::{BoardConnection, Connect, Disconnect, NearbyBoards, StartScan, StopScan},
     kilter_board::BoardAngle,
+    kilter_data::{ClimbFilter, KilterData},
     ui::{button::button, UiAssets},
 };
 
@@ -87,9 +88,14 @@ fn setup_nav_panel(mut commands: Commands, handles: Res<UiAssets>) {
 fn angle_button(
     query: Query<&Interaction, (With<AngleButton>, Changed<Interaction>)>,
     mut angle: ResMut<BoardAngle>,
+    mut filter: ResMut<ClimbFilter>,
+    data: Res<KilterData>,
 ) {
     if query.iter().any(|i| *i == Interaction::Pressed) {
         *angle = angle.next();
+
+        filter.angle = angle.0;
+        filter.update(&data);
     }
 }
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -160,13 +160,7 @@ fn update_selected_climb(
     climb_draft_text_query: Query<Entity, With<ClimbDraftText>>,
     climb_listed_text_query: Query<Entity, With<ClimbListedText>>,
 ) {
-    let Some(climb) = kilter
-        .climbs
-        .iter()
-        .nth(selected.0)
-        .or_else(|| kilter.climbs.iter().next())
-        .map(|(_, climb)| climb)
-    else {
+    let Some(climb) = kilter.climbs.get(&selected.0) else {
         return;
     };
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -1,6 +1,10 @@
 use bevy::prelude::*;
 
-use crate::{kilter_board::SelectedClimb, kilter_data::KilterData};
+use crate::{
+    kilter_board::{BoardAngle, SelectedClimb},
+    kilter_data::KilterData,
+    ui::UiAssets,
+};
 
 use super::theme;
 
@@ -27,12 +31,17 @@ struct ClimbUuidText;
 struct ClimbDraftText;
 #[derive(Component)]
 struct ClimbListedText;
+
+#[derive(Component)]
+struct ClimbRatingText;
+#[derive(Component)]
+struct ClimbAscentsText;
 #[derive(Component)]
 struct ClimbInfo;
 #[derive(Component)]
 struct ClimbMoreInfo;
 
-fn setup_info_panel(mut commands: Commands) {
+fn setup_info_panel(mut commands: Commands, handles: Res<UiAssets>) {
     let root = commands
         .spawn(Node {
             flex_direction: FlexDirection::Row,
@@ -57,32 +66,97 @@ fn setup_info_panel(mut commands: Commands) {
             parent
                 .spawn((
                     Node {
-                        column_gap: Val::Px(5.),
+                        row_gap: Val::Px(5.),
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
                     ClimbInfo,
                     Interaction::None,
                 ))
                 .with_children(|parent| {
-                    parent.spawn((
-                        Text::new("Name".to_string()),
-                        TextFont {
-                            font_size: theme::FONT_SIZE,
+                    parent
+                        .spawn(Node {
+                            column_gap: Val::Px(5.),
                             ..default()
-                        },
-                        TextColor(theme::FONT_COLOR_EMPHASIS.into()),
-                        ClimbNameText,
-                    ));
+                        })
+                        .with_children(|parent| {
+                            parent.spawn((
+                                Text::new("Name".to_string()),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE,
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR_EMPHASIS.into()),
+                                ClimbNameText,
+                            ));
 
-                    parent.spawn((
-                        Text::new("by Author".to_string()),
-                        TextFont {
-                            font_size: theme::FONT_SIZE,
+                            parent.spawn((
+                                Text::new("by".to_string()),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE,
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR_MUTED.into()),
+                            ));
+
+                            parent.spawn((
+                                Text::new("Author".to_string()),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE,
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR.into()),
+                                ClimbAuthorText,
+                            ));
+                        });
+                    parent
+                        .spawn(Node {
+                            column_gap: Val::Px(5.),
+                            align_items: AlignItems::Center,
                             ..default()
-                        },
-                        TextColor(theme::FONT_COLOR_MUTED.into()),
-                        ClimbAuthorText,
-                    ));
+                        })
+                        .with_children(|parent| {
+                            parent.spawn((
+                                Text::new("3.0".to_string()),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE,
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR_MUTED.into()),
+                                ClimbRatingText,
+                            ));
+
+                            parent.spawn((
+                                Text::new("\u{E17A}"),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE_SM,
+                                    font: handles.symbol_font.clone(),
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR_EMPHASIS.into()),
+                            ));
+
+                            parent.spawn((
+                                Text::new("123".to_string()),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE,
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR_MUTED.into()),
+                                ClimbAscentsText,
+                            ));
+
+                            parent.spawn((
+                                Text::new("\u{E1A4}"),
+                                TextFont {
+                                    font_size: theme::FONT_SIZE_SM,
+                                    font: handles.symbol_font.clone(),
+                                    ..default()
+                                },
+                                TextColor(theme::FONT_COLOR.into()),
+                            ));
+                        });
                 });
 
             parent
@@ -91,6 +165,7 @@ fn setup_info_panel(mut commands: Commands) {
                         flex_direction: FlexDirection::Column,
                         row_gap: Val::Px(3.),
                         display: Display::None,
+                        margin: UiRect::top(Val::Px(5.0)),
                         ..default()
                     },
                     ClimbMoreInfo,
@@ -151,6 +226,7 @@ fn setup_info_panel(mut commands: Commands) {
 fn update_selected_climb(
     selected: Res<SelectedClimb>,
     kilter: Res<KilterData>,
+    angle: Res<BoardAngle>,
     mut text_query: Query<&mut Text>,
     climb_name_text_query: Query<Entity, With<ClimbNameText>>,
     climb_author_text_query: Query<Entity, With<ClimbAuthorText>>,
@@ -159,6 +235,8 @@ fn update_selected_climb(
     climb_uuid_text_query: Query<Entity, With<ClimbUuidText>>,
     climb_draft_text_query: Query<Entity, With<ClimbDraftText>>,
     climb_listed_text_query: Query<Entity, With<ClimbListedText>>,
+    climb_rating_text_query: Query<Entity, With<ClimbRatingText>>,
+    climb_ascents_text_query: Query<Entity, With<ClimbAscentsText>>,
 ) {
     let Some(climb) = kilter.climbs.get(&selected.0) else {
         return;
@@ -178,9 +256,7 @@ fn update_selected_climb(
     let Ok(mut author_text) = text_query.get_mut(author_entity) else {
         return;
     };
-    author_text
-        .0
-        .clone_from(&format!("by {}", &climb.setter_username));
+    author_text.0.clone_from(&climb.setter_username);
 
     let Ok(angle_entity) = climb_angle_text_query.single() else {
         return;
@@ -234,6 +310,38 @@ fn update_selected_climb(
     listed_text
         .0
         .clone_from(&format!("Listed: {:?}", climb.is_listed));
+
+    let Ok(rating_entity) = climb_rating_text_query.single() else {
+        return;
+    };
+    let Ok(mut rating_text) = text_query.get_mut(rating_entity) else {
+        return;
+    };
+
+    let stats = kilter
+        .uuid_angle_to_stats
+        .get(&(selected.0.clone(), angle.0));
+
+    let rating = match stats {
+        Some(s) => format!("{:.1}", s.quality_average),
+        None => "?".to_string(),
+    };
+
+    rating_text.0.clone_from(&rating);
+
+    let Ok(ascents_entity) = climb_ascents_text_query.single() else {
+        return;
+    };
+    let Ok(mut ascents_text) = text_query.get_mut(ascents_entity) else {
+        return;
+    };
+
+    let ascents = match stats {
+        Some(s) => format!("{}", s.ascensionist_count),
+        None => "?".to_string(),
+    };
+
+    ascents_text.0.clone_from(&ascents);
 }
 
 fn toggle_more_info(

--- a/src/ui/nav_panel.rs
+++ b/src/ui/nav_panel.rs
@@ -144,14 +144,8 @@ fn grade_button(
         text.0.clone_from(&label);
     }
 
-    filter.filter_min_difficulty = match button.0 {
-        Some(d) => d,
-        None => 0,
-    };
-    filter.filter_max_difficulty = match button.0 {
-        Some(d) => d,
-        None => 33,
-    };
+    filter.filter_min_difficulty = button.0.unwrap_or(0);
+    filter.filter_max_difficulty = button.0.unwrap_or(33);
     filter.update(&data);
 }
 

--- a/src/ui/nav_panel.rs
+++ b/src/ui/nav_panel.rs
@@ -2,22 +2,28 @@ use bevy::prelude::*;
 
 use crate::{
     kilter_board::ChangeClimbEvent,
+    kilter_data::{ClimbFilter, KilterData},
     ui::{button::button, UiAssets},
 };
 
 use super::theme;
 
+const MIN_GRADE: u32 = 10;
+const MAX_GRADE: u32 = 27; // Up to 33 is valid
+
 #[derive(Component)]
 pub struct PrevButton;
 #[derive(Component)]
 pub struct NextButton;
+#[derive(Component)]
+pub struct GradeButton(Option<u32>);
 
 pub struct NavPanelPlugin;
 
 impl Plugin for NavPanelPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_nav_panel);
-        app.add_systems(Update, (prev_button, next_button));
+        app.add_systems(Update, (prev_button, next_button, grade_button));
     }
 }
 
@@ -37,6 +43,10 @@ fn setup_nav_panel(mut commands: Commands, handles: Res<UiAssets>) {
         ))
         .id();
 
+    let grade_button = commands
+        .spawn((button("Any", handles.font.clone()), GradeButton(None)))
+        .id();
+
     let prev_button = commands
         .spawn((button("\u{E04C}", handles.symbol_font.clone()), PrevButton))
         .id();
@@ -47,7 +57,7 @@ fn setup_nav_panel(mut commands: Commands, handles: Res<UiAssets>) {
 
     commands
         .entity(container)
-        .add_children(&[prev_button, next_button]);
+        .add_children(&[grade_button, prev_button, next_button]);
 }
 
 fn prev_button(
@@ -66,4 +76,63 @@ fn next_button(
     if query.iter().any(|i| *i == Interaction::Pressed) {
         writer.write(ChangeClimbEvent::Next);
     }
+}
+
+fn grade_button(
+    interactions: Query<&Interaction, (With<GradeButton>, Changed<Interaction>)>,
+    mut text_query: Query<&mut Text>,
+    mut buttons: Query<(&mut GradeButton, &Children)>,
+    data: Res<KilterData>,
+    mut filter: ResMut<ClimbFilter>,
+) {
+    if !interactions.iter().any(|i| *i == Interaction::Pressed) {
+        return;
+    };
+
+    let Ok((mut button, children)) = buttons.single_mut() else {
+        return;
+    };
+
+    button.0 = match button.0 {
+        Some(difficulty) => {
+            if difficulty + 1 > MAX_GRADE {
+                None
+            } else {
+                Some(difficulty + 1)
+            }
+        }
+        None => Some(MIN_GRADE),
+    };
+
+    let label = match button.0 {
+        Some(difficulty) => {
+            match data
+                .difficulty_grades
+                .get(&difficulty)
+                .map(|dg| dg.boulder_name.clone())
+            {
+                Some(l) => l,
+                None => {
+                    warn!("Failed to look up difficulty: {}", difficulty);
+                    return;
+                }
+            }
+        }
+        None => "Any".to_string(),
+    };
+
+    let mut iter = text_query.iter_many_mut(children);
+    while let Some(mut text) = iter.fetch_next() {
+        text.0.clone_from(&label);
+    }
+
+    filter.filter_min_difficulty = match button.0 {
+        Some(d) => d,
+        None => 0,
+    };
+    filter.filter_max_difficulty = match button.0 {
+        Some(d) => d,
+        None => 33,
+    };
+    filter.update(&data);
 }

--- a/src/ui/nav_panel.rs
+++ b/src/ui/nav_panel.rs
@@ -17,13 +17,24 @@ pub struct PrevButton;
 pub struct NextButton;
 #[derive(Component)]
 pub struct GradeButton(Option<u32>);
+#[derive(Component)]
+pub struct OverrideButton;
 
 pub struct NavPanelPlugin;
 
 impl Plugin for NavPanelPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_nav_panel);
-        app.add_systems(Update, (prev_button, next_button, grade_button));
+        app.add_systems(
+            Update,
+            (
+                prev_button,
+                next_button,
+                grade_button,
+                override_button,
+                override_button_style,
+            ),
+        );
     }
 }
 
@@ -43,6 +54,10 @@ fn setup_nav_panel(mut commands: Commands, handles: Res<UiAssets>) {
         ))
         .id();
 
+    let override_button = commands
+        .spawn((button("\u{E342}", handles.font.clone()), OverrideButton))
+        .id();
+
     let grade_button = commands
         .spawn((button("Any", handles.font.clone()), GradeButton(None)))
         .id();
@@ -55,9 +70,12 @@ fn setup_nav_panel(mut commands: Commands, handles: Res<UiAssets>) {
         .spawn((button("\u{E04D}", handles.symbol_font.clone()), NextButton))
         .id();
 
-    commands
-        .entity(container)
-        .add_children(&[grade_button, prev_button, next_button]);
+    commands.entity(container).add_children(&[
+        override_button,
+        grade_button,
+        prev_button,
+        next_button,
+    ]);
 }
 
 fn prev_button(
@@ -135,4 +153,34 @@ fn grade_button(
         None => 33,
     };
     filter.update(&data);
+}
+
+fn override_button(
+    query: Query<&Interaction, (With<OverrideButton>, Changed<Interaction>)>,
+    mut filter: ResMut<ClimbFilter>,
+    data: Res<KilterData>,
+) {
+    if query.iter().any(|i| *i == Interaction::Pressed) {
+        filter.override_climbs.clear();
+        filter.update(&data);
+    }
+}
+
+fn override_button_style(
+    filter: Res<ClimbFilter>,
+    mut buttons: Query<&mut Node, With<OverrideButton>>,
+) {
+    if !filter.is_changed() {
+        return;
+    }
+
+    let Ok(mut node) = buttons.single_mut() else {
+        return;
+    };
+
+    node.display = if filter.override_climbs.is_empty() {
+        Display::None
+    } else {
+        Display::Flex
+    }
 }

--- a/src/ui/search_panel.rs
+++ b/src/ui/search_panel.rs
@@ -11,7 +11,7 @@ struct SearchField;
 #[derive(Component)]
 struct SearchResultsPanel;
 #[derive(Component)]
-struct SearchResultItem(usize);
+struct SearchResultItem(String);
 #[derive(Component)]
 struct SearchPanel;
 
@@ -93,12 +93,13 @@ fn update_search_results(
     // Despawn existing search result entities
     commands.entity(panel_entity).despawn_related::<Children>();
 
+    // TODO maybe should probably search filtered climbs, not all climbs
     let results = kilter.search_by_name(&search_text.0);
     if results.is_empty() {
         return;
     }
 
-    for (climb_idx, climb) in results.iter().take(10) {
+    for (_climb_idx, climb) in results.iter().take(10) {
         let result = commands
             .spawn((
                 Button,
@@ -109,11 +110,11 @@ fn update_search_results(
                 },
                 BorderRadius::all(theme::CONTAINER_BORDER_RADIUS),
                 BackgroundColor(theme::CONTAINER_BG.into()),
-                SearchResultItem(*climb_idx),
+                SearchResultItem(climb.uuid.clone()),
             ))
             .with_children(|parent| {
                 parent.spawn((
-                    Text::new(format!("{}: {}", climb_idx, climb.name)),
+                    Text::new(&climb.name),
                     TextFont {
                         font_size: theme::FONT_SIZE_SM,
                         ..default()
@@ -133,7 +134,7 @@ fn handle_search_result_click(
 ) {
     for (interaction, item) in &query {
         if *interaction == Interaction::Pressed {
-            writer.write(ChangeClimbEvent::SelectByIndex(item.0));
+            writer.write(ChangeClimbEvent::SelectByUuid(item.0.clone()));
         }
     }
 }

--- a/src/ui/search_panel.rs
+++ b/src/ui/search_panel.rs
@@ -93,7 +93,7 @@ fn update_search_results(
     // Despawn existing search result entities
     commands.entity(panel_entity).despawn_related::<Children>();
 
-    // TODO maybe should probably search filtered climbs, not all climbs
+    // TODO probably should search filtered climbs, not all climbs
     let results = kilter.search_by_name(&search_text.0);
     if results.is_empty() {
         return;


### PR DESCRIPTION
Add filtering by grade, and sorting by rating.

This made handling paste events and climb generation responses slightly awkward or impossible to navigate when there were multiple climbs.

To work around this, there's an override for the filters so that the contents of the latest paste/generation are always shown instead of the filtered routes. An indicator appears near the grade filter which you can tap to get back to the filtered climbs.