### PR TITLE
Custom roles

### DIFF
--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use bevy::window::WindowMode;
 use bevy::winit::WinitSettings;
@@ -33,15 +34,20 @@ fn main() {
     App::new()
         .insert_resource(kd)
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    resizable: false,
-                    mode: WindowMode::BorderlessFullscreen(MonitorSelection::Current),
-                    recognize_pinch_gesture: true,
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        resizable: false,
+                        mode: WindowMode::BorderlessFullscreen(MonitorSelection::Current),
+                        recognize_pinch_gesture: true,
+                        ..default()
+                    }),
+                    ..default()
+                })
+                .set(LogPlugin {
+                    filter: "kilter_brain=debug".into(),
                     ..default()
                 }),
-                ..default()
-            }),
             AppPlugin,
             BlePlugin,
         ))

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -103,6 +103,10 @@ fn cycle(
             Some(12),
             // finish
             Some(14),
+            // CUSTOM cheat hold
+            Some(99),
+            // CUSTOM match allowed
+            Some(98),
             None,
         ];
 

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -141,7 +141,7 @@ fn cycle(
         // Update frames
 
         let frames = placements.iter().fold(String::new(), |mut acc, (k, v)| {
-            acc.push_str(&format!("p{}r{}", k, v));
+            acc.push_str(&format!("p{k}r{v}"));
             acc
         });
 

--- a/src/authoring.rs
+++ b/src/authoring.rs
@@ -1,43 +1,44 @@
 use bevy::{
     input::gestures::PinchGesture,
     picking::events::{Click, DragEnd, Pointer},
+    platform::collections::HashMap,
     prelude::*,
 };
 
+use combine::EasyParser;
 use uuid::Uuid;
-
-use std::fmt::Write;
 
 use crate::{
     clipboard::PasteEvent,
-    kilter_board::{Board, KilterSettings, SelectedClimb},
-    kilter_data::{parse_placements_and_roles, Climb, ClimbFilter, KilterData},
-    placement_indicator::PlacementIndicator,
+    kilter_board::{Board, ChangeClimbEvent, KilterSettings, SelectedClimb},
+    kilter_data::{
+        parse_placements_and_roles, placements_and_roles, Climb, ClimbFilter, KilterData,
+    },
 };
 
 pub struct AuthoringPlugin;
 
 impl Plugin for AuthoringPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (cycle, log_frames, on_paste));
+        app.add_systems(Update, (cycle, on_paste));
     }
 }
 
 fn cycle(
-    mut commands: Commands,
-    mut indicator_query: Query<(Entity, &mut PlacementIndicator)>,
-    board_query: Query<(Entity, &GlobalTransform), With<Board>>,
+    board_query: Query<&GlobalTransform, With<Board>>,
     mut click_events: EventReader<Pointer<Click>>,
     mut drag_end: EventReader<Pointer<DragEnd>>,
     mut pinch_events: EventReader<PinchGesture>,
-    kilter: Res<KilterData>,
+    mut kilter: ResMut<KilterData>,
     settings: Res<KilterSettings>,
+    selected: Res<SelectedClimb>,
+    mut events: EventWriter<ChangeClimbEvent>,
 ) {
     let pinching = pinch_events.read().len() > 0;
     let drag_dist = drag_end.read().map(|e| e.event.distance).sum::<Vec2>();
 
     for event in click_events.read() {
-        let Ok((board_entity, board)) = board_query.get(event.target) else {
+        let Ok(board) = board_query.get(event.target) else {
             continue;
         };
 
@@ -48,6 +49,19 @@ fn cycle(
         if pinching {
             continue;
         }
+
+        let Some(climb) = kilter.climbs.get(&selected.0) else {
+            continue;
+        };
+
+        let placements = placements_and_roles()
+            .easy_parse(climb.frames.as_str())
+            .map(|(pr, _err)| pr)
+            .unwrap_or_else(|_| Vec::new());
+
+        let mut placements = HashMap::<u32, u32>::from_iter(placements);
+
+        // Find closest placement to cursor hit position
 
         let mut min: Option<(u32, Vec2, f32)> = None;
 
@@ -75,22 +89,15 @@ fn cycle(
             }
         }
 
-        let Some((placement_id, _, _d_squared)) = min else {
+        let Some((closest_placement_id, _, _d_squared)) = min else {
             continue;
         };
-
-        // TODO consider monitoring the selected climb's frame data directly
-        // and updating the indicators in a separate system.
-
-        let search = indicator_query
-            .iter_mut()
-            .find(|(_, p)| p.placement_id == placement_id);
 
         // Determine the order of roles to cycle through.
 
         let first_role_id = kilter
             .placements
-            .get(&placement_id)
+            .get(&closest_placement_id)
             .and_then(|p| p.default_placement_role_id)
             .unwrap_or(13);
 
@@ -116,48 +123,37 @@ fn cycle(
             }
         }
 
-        if let Some((entity, mut placement)) = search {
-            let current = roles
-                .iter()
-                .position(|r| *r == Some(placement.role_id))
-                .unwrap();
-            let next = roles.iter().cycle().nth(current + 1).unwrap();
+        // Update placement in hashmap
 
-            if let Some(next) = next {
-                placement.role_id = *next;
-            } else {
-                commands.entity(entity).despawn();
+        let entry = placements
+            .entry(closest_placement_id)
+            .or_insert(roles.first().unwrap().unwrap());
+        let current = *entry;
+        let current_ind = roles.iter().position(|r| *r == Some(current)).unwrap();
+
+        match roles.iter().cycle().nth(current_ind + 1).unwrap() {
+            Some(next) => *entry = *next,
+            None => {
+                placements.remove(&closest_placement_id);
             }
-        } else {
-            // TODO if there are already two start holds on the board,
-            // don't use that role even if it's the default.
-
-            let indicator = commands
-                .spawn(PlacementIndicator {
-                    placement_id,
-                    role_id: roles.first().unwrap().unwrap(),
-                })
-                .id();
-            commands.entity(board_entity).add_child(indicator);
         }
+
+        // Update frames
+
+        let frames = placements.iter().fold(String::new(), |mut acc, (k, v)| {
+            acc.push_str(&format!("p{}r{}", k, v));
+            acc
+        });
+
+        let Some(climb) = kilter.climbs.get_mut(&selected.0) else {
+            continue;
+        };
+
+        climb.frames = frames;
+
+        // Cause board to be updated, and new frames to be sent over bluetooth
+        events.write(ChangeClimbEvent::SelectByUuid(climb.uuid.clone()));
     }
-}
-
-fn log_frames(
-    query: Query<&PlacementIndicator>,
-    changed_query: Query<(), Changed<PlacementIndicator>>,
-) {
-    // TODO this iterates the entire query. Use an event or something.
-    if changed_query.is_empty() {
-        return;
-    }
-
-    let out: String = query.iter().fold(String::new(), |mut out, ind| {
-        let _ = write!(out, "{ind}");
-        out
-    });
-
-    info!("{out}");
 }
 
 fn on_paste(

--- a/src/board_connection.rs
+++ b/src/board_connection.rs
@@ -54,18 +54,45 @@ impl WriteToBoard {
         let positions = pr
             .iter()
             .flat_map(|(placement_id, role_id)| {
-                let color = match *role_id {
-                    12 => (0, 255, 0),
-                    13 => (0, 255, 255),
-                    14 => (255, 0, 255),
-                    15 => (255, 165, 0),
-                    _ => (0, 0, 0),
-                };
-                let position = kd.placement_id_to_led_position.get(placement_id)?;
-                Some((*position as u16, color))
+                let hex = kd
+                    .placement_roles
+                    .get(role_id)
+                    .map(|pr| &pr.led_color)
+                    .or_else(|| {
+                        error!("Role lookup failed: {role_id}");
+                        None
+                    })?;
+
+                let rgb = hex_to_rgb(hex)
+                    .map_err(|e| {
+                        error!("Error converting color: {e}");
+                    })
+                    .ok()?;
+
+                let position = kd
+                    .placement_id_to_led_position
+                    .get(placement_id)
+                    .or_else(|| {
+                        error!("Position lookup failed: {role_id}");
+                        None
+                    })?;
+
+                Some((*position as u16, rgb))
             })
             .collect::<Vec<_>>();
 
         Self(positions)
     }
+}
+
+fn hex_to_rgb(hex: &str) -> Result<(u8, u8, u8), &'static str> {
+    if hex.len() != 6 {
+        return Err("Hex string must be 6 characters long");
+    }
+
+    let r = u8::from_str_radix(&hex[0..2], 16).map_err(|_| "Invalid red component")?;
+    let g = u8::from_str_radix(&hex[2..4], 16).map_err(|_| "Invalid green component")?;
+    let b = u8::from_str_radix(&hex[4..6], 16).map_err(|_| "Invalid blue component")?;
+
+    Ok((r, g, b))
 }

--- a/src/kilter_board.rs
+++ b/src/kilter_board.rs
@@ -152,15 +152,13 @@ fn change_climb(
                     .get_index_of(&selected.0)
                     .unwrap_or(0);
 
-                info!("Current index: {current_index}");
-
                 let prev_index = if current_index == 0 {
                     filter.filtered_climbs.len() - 1
                 } else {
                     current_index - 1
                 };
 
-                info!("Prev index: {prev_index}");
+                debug!("Navigating. {current_index} -> {prev_index}");
 
                 if let Some(prev_uuid) = filter.filtered_climbs.get_index(prev_index) {
                     selected.0 = prev_uuid.clone();
@@ -176,15 +174,13 @@ fn change_climb(
                     .get_index_of(&selected.0)
                     .unwrap_or(0);
 
-                info!("Current index: {current_index}");
-
                 let next_index = if current_index + 1 >= filter.filtered_climbs.len() {
                     0
                 } else {
                     current_index + 1
                 };
 
-                info!("Next index: {next_index}");
+                debug!("Navigating. {current_index} -> {next_index}");
 
                 if let Some(next_uuid) = filter.filtered_climbs.get_index(next_index) {
                     selected.0 = next_uuid.clone();
@@ -234,6 +230,8 @@ fn show_climb(
 
         commands.entity(board).add_child(indicator);
     }
+
+    debug!("Showing frames: {}", climb.frames);
 
     events.write(WriteToBoard::from_positions_and_roles(&placements, &kilter));
 }

--- a/src/kilter_data.rs
+++ b/src/kilter_data.rs
@@ -111,11 +111,12 @@ impl KilterData {
             .prepare(
                 "SELECT
                     id, product_id, position,name, full_name, led_color, screen_color
-                FROM placement_roles",
+                FROM placement_roles
+                WHERE product_id = 1",
             )
             .unwrap();
 
-        let placement_roles = stmt
+        let mut placement_roles = stmt
             .query_map([], |row| {
                 Ok((
                     row.get(0)?,
@@ -132,7 +133,32 @@ impl KilterData {
             })
             .unwrap()
             .flatten()
-            .collect();
+            .collect::<HashMap<_, _>>();
+
+        placement_roles.insert(
+            99,
+            PlacementRole {
+                id: 99,
+                product_id: 1,
+                name: "cheat".to_string(),
+                full_name: "Cheat".to_string(),
+                position: 99,
+                led_color: "FF0000".to_string(),
+                screen_color: "FF0000".to_string(),
+            },
+        );
+        placement_roles.insert(
+            98,
+            PlacementRole {
+                id: 98,
+                product_id: 1,
+                name: "match".to_string(),
+                full_name: "Match".to_string(),
+                position: 98,
+                led_color: "FFFFFF".to_string(),
+                screen_color: "FFFFFF".to_string(),
+            },
+        );
 
         let mut stmt = conn
             .prepare(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{log::LogPlugin, prelude::*};
 
 use kilter_brain::{kilter_data::KilterData, AppPlugin};
 
@@ -23,7 +23,10 @@ fn main() {
 
     App::new()
         .insert_resource(kd)
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(LogPlugin {
+            filter: "kilter_brain=debug".into(),
+            ..default()
+        }))
         .add_plugins(AppPlugin)
         .run();
 }

--- a/src/ui/action_panel.rs
+++ b/src/ui/action_panel.rs
@@ -8,7 +8,7 @@ use crate::{
     effects::PartyMode,
     gen_api::{GenApiSettings, GeneratedClimb, GeneratedClimbs},
     kilter_board::{BoardAngle, SelectedClimb},
-    kilter_data::{Climb, KilterData},
+    kilter_data::{Climb, ClimbFilter, KilterData},
     placement_indicator::PlacementIndicator,
     ui::{button::button, UiAssets},
 };
@@ -135,6 +135,7 @@ fn clear_button(
 fn new_button(
     query: Query<&Interaction, (With<NewButton>, Changed<Interaction>)>,
     mut kilter: ResMut<KilterData>,
+    mut filter: ResMut<ClimbFilter>,
     mut selected: ResMut<SelectedClimb>,
 ) {
     if query.iter().any(|i| *i == Interaction::Pressed) {
@@ -149,6 +150,10 @@ fn new_button(
                 ..default()
             },
         );
+
+        filter.override_climbs.clear();
+        filter.override_climbs.insert(id.clone());
+        filter.update(&kilter);
 
         selected.0 = id.clone();
     }


### PR DESCRIPTION
Adds some custom roles for climb authoring, as a proof-of-concept.

RED - designated cheat hold
WHITE - matching allowed

This also reworks the placement cycling code so that we can immediately display the results via bluetooth.

TODO: We need to be careful with these and never publish climbs that contain them. Maybe I should just remove the publish button for now. This also means we need to figure out a mechanism for persisting climbs either local-only, or via the `kilter_brain_gen` API.

TODO: We should have a toggle that disables these extra roles during authoring.